### PR TITLE
お問い合わせ機能の追加とDB登録処理を追加

### DIFF
--- a/practice/pom.xml
+++ b/practice/pom.xml
@@ -54,8 +54,21 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf</artifactId> 
-		 </dependency>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+</dependency>
 		
 	</dependencies>
 

--- a/practice/src/main/java/com/example/demo/controller/ContactController.java
+++ b/practice/src/main/java/com/example/demo/controller/ContactController.java
@@ -1,31 +1,94 @@
 package com.example.demo.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.servlet.ModelAndView;
 
-import com.example.demo.data.ContactData;
+import com.example.demo.entity.Contact;
+import com.example.demo.form.ContactForm;
+import com.example.demo.repository.ContactRepository;
 
 @Controller
 public class ContactController {
+
+	@Autowired
+	private ContactRepository contactRepository;
+
+	@GetMapping("/contact")
+	public String contact(Model model) {
+		model.addAttribute("contactForm", new ContactForm());
+
+		return "contact";
+	}
+
 	@PostMapping("/contact")
-	public ModelAndView contact(@ModelAttribute ContactData contactData, ModelAndView mv) {
-			
-		mv.setViewName("confirmation");
+	public String contact(@Validated @ModelAttribute("contactForm") ContactForm contactForm, BindingResult errorResult,
+			HttpServletRequest request) {
 
-		mv.addObject("lastName",  contactData.getLastName());
-		mv.addObject("firstName", contactData.getFirstName());
-		mv.addObject("email", contactData.getEmail());
-		mv.addObject("phone", contactData.getPhone());
-		mv.addObject("zipCode", contactData.getZipCode());
-		mv.addObject("address", contactData.getAddress());
-		mv.addObject("buildingName", contactData.getBuildingName());
-		mv.addObject("contactType", contactData.getContactType());
-		mv.addObject("body", contactData.getBody());
-		
+		if (errorResult.hasErrors()) {
+			return "contact";
+		}
 
-		return mv;
+		HttpSession session = request.getSession();
+		session.setAttribute("contactForm", contactForm);
+
+		return "redirect:/contact/confirm";
+	}
+
+	@GetMapping("/contact/confirm")
+	public String confirm(Model model, HttpServletRequest request) {
+		HttpSession session = request.getSession();
+
+		ContactForm contactForm = (ContactForm) session.getAttribute("contactForm");
+		model.addAttribute("contactForm", contactForm);
+		return "confirmation";
+	}
+
+	@PostMapping("/contact/register")
+	public String register(Model model, HttpServletRequest request) {
+
+		HttpSession session = request.getSession();
+		ContactForm contactForm = (ContactForm) session.getAttribute("contactForm");
+
+		Contact contact = new Contact();
+		contact.setLastName(contactForm.getLastName());
+		contact.setFirstName(contactForm.getFirstName());
+		contact.setEmail(contactForm.getEmail());
+		contact.setPhone(contactForm.getPhone());
+		contact.setZipCode(contactForm.getZipCode());
+		contact.setAddress(contactForm.getAddress());
+		contact.setBuildingName(contactForm.getBuildingName());
+		contact.setContactType(contactForm.getContactType());
+		contact.setBody(contactForm.getBody());
+
+		contactRepository.save(contact);
+
+		return "redirect:/contact/complete";
+
+	}
+
+	@GetMapping("/contact/complete")
+	public String complete(Model model, HttpServletRequest request) {
+
+		if (request.getSession(false) == null) {
+			return "redirect:/contact";
+		}
+
+		HttpSession session = request.getSession();
+		ContactForm contactForm = (ContactForm) session.getAttribute("contactForm");
+		model.addAttribute("contactForm", contactForm);
+
+		session.invalidate();
+
+		return "completion";
 
 	}
 

--- a/practice/src/main/java/com/example/demo/entity/Contact.java
+++ b/practice/src/main/java/com/example/demo/entity/Contact.java
@@ -1,0 +1,48 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.Data;
+
+@Entity
+@Data
+@Table(name = "contacts")
+public class Contact {
+	@Id
+	@GeneratedValue(strategy=GenerationType.AUTO)
+	@Column(name = "id")
+	private Long id;
+	
+	@Column(name = "last_name", nullable = false)
+	private String lastName;
+	
+	@Column(name = "first_name", nullable = false)
+	private String firstName;
+	
+	@Column(name = "email", nullable = false)
+	private String email;
+	
+	@Column(name = "phone", nullable = false)
+	private String phone;
+	
+	@Column(name = "zip_code", nullable = false)
+	private String zipCode;
+	
+	@Column(name = "address", nullable = false)
+	private String address;
+	
+	@Column(name = "building_name", nullable = false)
+	private String buildingName;
+	
+	@Column(name = "contact_type", nullable = false)
+	private String contactType;
+	
+	@Column(name = "body", nullable = false)
+	private String body;
+	
+}

--- a/practice/src/main/java/com/example/demo/form/ContactForm.java
+++ b/practice/src/main/java/com/example/demo/form/ContactForm.java
@@ -1,0 +1,45 @@
+package com.example.demo.form;
+
+import java.io.Serializable;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import lombok.Data;
+
+@Data
+public class ContactForm implements Serializable {
+	@NotBlank
+	private String lastName;
+	
+	@NotBlank
+	private String firstName;
+	
+	@NotBlank
+	@Email
+	private String email;
+	
+	@NotBlank
+	@Size(min = 10, max = 11)
+	private String phone;
+	
+	@NotBlank
+	@Pattern(regexp = "[0-9]{3}[-]{0,1}[0-9]{4}")
+	private String zipCode;
+	
+	@NotBlank
+	private String address;
+	
+	@NotBlank
+	private String buildingName;
+	
+	@NotEmpty
+	private String contactType;
+	
+	@NotBlank
+	private String body;
+
+}

--- a/practice/src/main/java/com/example/demo/repository/ContactRepository.java
+++ b/practice/src/main/java/com/example/demo/repository/ContactRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.demo.entity.Contact;
+
+public interface ContactRepository extends JpaRepository<Contact, Long>{
+
+}

--- a/practice/src/main/resources/application.properties
+++ b/practice/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=practice
+spring.datasource.url=jdbc:mysql://localhost:3306/contact_practice
+spring.datasource.username=spring_user
+spring.datasource.password={pass}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=update

--- a/practice/src/main/resources/templates/completion.html
+++ b/practice/src/main/resources/templates/completion.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<title>お問い合わせ完了</title>
+</head>
+<body>
+	<h1>お問い合わせいただきありがとうございました。</h1>
+	<p>後日弊社スタッフより<span th:text="${contactForm.email}"></span>宛にご連絡させていただきます。</p>
+</body>
+</html>

--- a/practice/src/main/resources/templates/confirmation.html
+++ b/practice/src/main/resources/templates/confirmation.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<title>お問合せ内容の確認</title>
+</head>
+<body>
+	<h1>お問合せ内容の確認</h1>
+	<form th:action="@{/contact/register}" th:object="${contactForm}" method="post">
+		<table border="1">
+			<tr>
+				<td>姓</td>
+				<td>
+					<span th:text="*{lastName}"></span>
+				</td>
+			</tr>
+			<tr>
+				<td>名</td>
+				<td>
+					<span th:text="*{firstName}"></span>
+				</td>
+			</tr>
+			
+			<tr>
+				<td>メールアドレス</td>
+				<td>
+					<span th:text="*{email}"></span>
+				</td>
+			</tr>
+			<tr>
+				<td>電話番号</td>
+				<td>
+					<span th:text="*{phone}"></span>
+				</td>
+			</tr>
+			<tr>
+				<td>郵便番号</td>
+				<td>
+					<span th:text="*{zipCode}"></span>
+				</td>
+			</tr>
+			<tr>
+				<td>住所</td>
+				<td>
+					<span th:text="*{address}"></span>
+				</td>
+			</tr>
+			<tr>
+				<td>建物名</td>
+				<td>
+					<span th:text="*{buildingName}"></span>
+				</td>
+			</tr>
+			<tr>
+				<td>お問い合わせ種別</td>
+				<td>
+					<span th:text="*{contactType}"></span>
+				</td>
+			</tr>
+			<tr>
+				<td>お問い合わせ内容</td>
+				<td>
+					<span th:text="*{body}"></span>
+				</td>
+			</tr>
+			</table>
+			<input type="submit" value="送信">
+		</form>					
+</body>
+</html>

--- a/practice/src/main/resources/templates/contact.html
+++ b/practice/src/main/resources/templates/contact.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<title>お問い合わせ</title>
+</head>
+<body>
+　 <h1>お問い合わせ</h1>
+   <form th:action="@{/contact}" th:object="${contactForm}" method="post">
+	 <table border="1">
+		<tr>
+			<td>姓</td>
+			<td>
+				<input type="text" th:field="*{lastName}">
+				<span th:if="${#fields.hasErrors('lastName')}" th:errors="*{lastName}" style="color: red"></span> 
+			</td>
+			
+		</tr>
+		<tr>
+			<td>名</td>
+			<td>
+				<input type="text" th:field="*{firstName}">
+				<span th:if="${#fields.hasErrors('firstName')}" th:errors="*{firstName}" style="color: red"></span> 
+			</td>
+		</tr>
+		<tr>
+			<td>メールアドレス</td>
+			<td>
+				<input type="email" th:field="*{email}">
+				<span th:if="${#fields.hasErrors('email')}" th:errors="*{email}" style="color: red"></span>
+				 
+			</td>
+		</tr>
+		<tr>
+			<td>電話番号</td>
+			<td>
+				<input type="tel" th:field="*{phone}">
+				<span th:if="${#fields.hasErrors('phone')}" th:errors="*{phone}" style="color: red"></span>
+			</td>
+		</tr>
+		<tr>
+			<td>郵便番号</td>
+			<td>
+				<input type="text" th:field="*{zipCode}">
+				<span th:if="${#fields.hasErrors('zipCode')}" th:errors="*{zipCode}" style="color: red"></span>
+			</td>
+		</tr>
+		<tr>
+			<td>住所</td>
+			<td>
+				<input type="text" th:field="*{address}">
+				<span th:if="${#fields.hasErrors('address')}" th:errors="*{address}" style="color: red"></span>
+			</td>
+		</tr>
+		<tr>
+			<td>建物名</td>
+			<td>
+				<input type="text" th:field="*{buildingName}">
+				<span th:if="${#fields.hasErrors('buildingName')}" th:errors="*{buildingName}" style="color: red"></span>
+			</td>
+		</tr>
+		<tr>
+			<td>お問い合わせ種別</td>
+			<td>
+				<select name="contactType">
+					<option th:value="services">サービスに関するお問い合わせ</option>
+					<option th:value="technicalQuestions">技術的なお問い合わせ</option>
+					<option th:value="others">その他</option>
+				</select>
+				<span th:if="${#fields.hasErrors('contactType')}" th:errors="*{contactType}" style="color: red"></span>
+			</td>
+		</tr>
+		<tr>
+			<td>お問い合わせ内容</td>
+			<td>
+				<textarea th:field="*{body}" row="4" cols="80"></textarea>
+				<span th:if="${#fields.hasErrors('body')}" th:errors="*{body}" style="color: red"></span>
+			</td>
+		</tr>
+	   </table>
+	   <input type="submit" value="送信">
+	 </form>
+</body>
+</html>


### PR DESCRIPTION
# カリキュラム名
お問い合わせフォーム実装３
# やったこと/レビュー観点
お問い合わせフォームからDB登録処理を追加しました。
・フォーム表示、バリデーション、セッション管理、リダイレクトを実装
・ContactForm（入力値の受け取り）、Contact Entity（DBテーブル）、ContactRepository（DB操作）を実装
・Thymeleafテンプレート（contact, confirmation, completion）を設置
ご確認よろしくお願いします。